### PR TITLE
Use Gravatar instead of FullContact API.

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -6,7 +6,5 @@
 #   with others, such as API Keys, local database links, or the combination to
 #   your locker.
 
-FULL_CONTACT_API_KEY="your api key goes here"
-
 #This ENV is used during Production and Staging since Heroku doesn't like Sqlite3
 DATABASE_URL=postgres://user:password@localhost/database

--- a/README.md
+++ b/README.md
@@ -1,11 +1,7 @@
 A web-based, local check-in app based on the chat app written using PakyowUI.
 
 PURPOSE:
-* Enter an email address and an objective for attending the event. The app finds profile information based on that email address, grabs a picture and a name from an API response (from Full Contact) and posts a "Profile" and the Objective.  This allows everyone at the event to see a name to a face, along with an objective so everyone can help that person get the best experience for the event.
-
-NEED: 
-* Will need a FullContact API developer key, entered in your .env file. 
-https://www.fullcontact.com/developer/docs/
+* Enter an email address and an objective for attending the event. The app finds profile information based on that email address, grabs a picture and a name from an API response (from Gravatar) and posts a "Profile" and the Objective.  This allows everyone at the event to see a name to a face, along with an objective so everyone can help that person get the best experience for the event.
 
 TODO's:
 * Front End:
@@ -31,13 +27,6 @@ Make sure you have a reasonably recent version of Ruby installed (> 2.0), along
 with RubyGems and Bundler. Then, install the dependencies:
 
 		bundle install
-
-Next, you'll need to define your FullContact developer api key in a file named
-`.env` in the root directory of the project. You can signup for a free account
-at the 
-[FullContact Developer API Signup](https://www.fullcontact.com/developer/pricing/) 
-page. Once you have your key, you can copy the `.env.template` file to `.env` and
-fill in your api key.
 
 Finally, start the app server:
 

--- a/app/lib/models/gravatar.rb
+++ b/app/lib/models/gravatar.rb
@@ -1,0 +1,47 @@
+require 'digest'
+
+class Gravatar
+
+  attr_reader :avatar_url, :display_name
+
+  def initialize(email_hash, profile)
+    @email_hash = email_hash
+    @profile = profile['entry'][0]
+  end
+
+  def avatar_url
+    "http://www.gravatar.com/avatar/#{@email_hash}"
+  end
+
+  def display_name
+    @profile['displayName']
+  end
+
+
+  class << self
+
+    def fetch(email_address)
+      email_hash = hash email_address
+      response = HTTParty.get profile_url(email_hash)
+
+      if response.code == 200 then
+        result = JSON.parse(response.body)
+        Gravatar.new(email_hash, result)
+      end
+    end
+
+    def profile_url(email_hash)
+      "http://www.gravatar.com/#{email_hash}.json"
+    end
+
+    def hash(s)
+      md5 = Digest::MD5.new
+      md5.update s
+      md5.hexdigest
+    end
+
+  end
+
+  private_class_method :hash
+
+end

--- a/app/lib/routes.rb
+++ b/app/lib/routes.rb
@@ -20,34 +20,19 @@ Pakyow::App.routes do
 
     create do
       #Getting email prop being submitted in form in profile view
-      email_str = params[:profile][:email]
-
-      #Building components of the API URL to Full Contact
-      base_url = "https://api.fullcontact.com/v2/person.json?email="
-      conj_url = "&apiKey="
-      apiKey = ENV['FULL_CONTACT_API_KEY']
-      # You can get a trial Full Contact API key from:
-      # https://www.fullcontact.com/developer/try-fullcontact/
-
-      url = [base_url, email_str, conj_url, apiKey].join
-
-      #Calling API to get JSON response for parsing
-      response = HTTParty.get(url)
-      result = JSON.parse(response.body)
+      profile = params[:profile]
+      gravatar = Gravatar.fetch(profile[:email])
 
       #If API response successful create record; else output error to view
-      if result['status'] == 200 then
-        image_url = result['photos'][0]['url']
-        name = result['contactInfo']['fullName']
-        # p "Inspect params in Route Create:"
-        # p params.inspect
-        data(:profile).create(params[:profile].merge(:name => name, :imgurl => image_url))
-        # p "Profile.all from Route Create:"
-        # p Profile.all
+      if gravatar then
+        profile.merge! name: gravatar.display_name, imgurl: gravatar.avatar_url
+
+        data(:profile).create(profile)
         redirect router.group(:profile).path(:list)
+
         #TODO: after record creation, re-autofocus form to email field
       else
-        p "Couldn't find " + params[:profile][:email]
+        p "Couldn't find #{profile[:email]}"
         #TODO: Output error to view
       end
 


### PR DESCRIPTION
This commit removes the use of the FullContact API and replaces it with code that interfaces with Gravatar endpoints.

Fixes #7.